### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/starfish-prod-ci.yml
+++ b/.github/workflows/starfish-prod-ci.yml
@@ -1,5 +1,7 @@
 
 name: starfish-prod-ci
+permissions:
+  contents: read
 
 on:
 


### PR DESCRIPTION
Potential fix for [https://github.com/shachafl/starfish/security/code-scanning/16](https://github.com/shachafl/starfish/security/code-scanning/16)

To fix the problem, you should add an explicit `permissions` block restricting the permissions of the `GITHUB_TOKEN` at either the workflow root or at the job level. In this workflow, since none of the jobs appear to require write access (they are focused on linting, dependency management, and test running), the appropriate minimal permission is `contents: read` at the workflow level. This ensures all jobs use the least privilege necessary and prevents any inadvertent upgrade to write permission in the future. You should add the block under the workflow `name:` and `on:` section, ensuring it applies to all jobs which do not set their own permissions.

Specifically, in `.github/workflows/starfish-prod-ci.yml`, after the workflow `name` and before `on:`, add:

```yaml
permissions:
  contents: read
```

No imports, methods, or other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
