### PR TITLE
Shachafl ipython magic patch 1

### DIFF
--- a/.github/workflows/starfish-prod-ci.yml
+++ b/.github/workflows/starfish-prod-ci.yml
@@ -459,7 +459,7 @@ jobs:
         run: |
           make TESTING=1 iss_pipeline.py
 
-dartfish-pipeline-data-processing-example:
+  dartfish-pipeline-data-processing-example:
     name: dartfish_pipeline.py Data Processing Example
     needs: starfish-slow
     runs-on: ubuntu-latest

--- a/.github/workflows/starfish-prod-ci.yml
+++ b/.github/workflows/starfish-prod-ci.yml
@@ -458,3 +458,28 @@ jobs:
       - name: Run Data Processing Example Test
         run: |
           make TESTING=1 iss_pipeline.py
+
+dartfish-pipeline-data-processing-example:
+    name: dartfish_pipeline.py Data Processing Example
+    needs: starfish-slow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.9'
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.OS }}-${{ env.pythonLocation }}-${{ hashFiles('requirements/REQUIREMENTS-CI.txt') }}
+
+      - name: Install Dependencies
+        run: |
+          make install-dev
+
+      - name: Run Data Processing Example Test
+        run: |
+          make dartfish_pipeline.py

--- a/.github/workflows/starfish-prod-ci.yml
+++ b/.github/workflows/starfish-prod-ci.yml
@@ -461,7 +461,7 @@ jobs:
 
   dartfish-pipeline-data-processing-example:
     name: dartfish_pipeline.py Data Processing Example
-    needs: starfish-slow
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -479,6 +479,7 @@ jobs:
       - name: Install Dependencies
         run: |
           make install-dev
+          pip install -r requirements/REQUIREMENTS-NAPARI-CI.txt
 
       - name: Run Data Processing Example Test
         run: |

--- a/examples/pipelines/dartfish_pipeline.py
+++ b/examples/pipelines/dartfish_pipeline.py
@@ -16,11 +16,15 @@ from raw images into spatially resolved gene expression profiles
 from IPython import get_ipython
 import matplotlib
 import matplotlib.pyplot as plt
+import sys
 
-# equivalent to %gui qt and %matplotlib inline
+# equivalent to using in a notebook cell: %matplotlib inline
 ipython = get_ipython()
-ipython.run_line_magic("gui", "qt5")
-ipython.run_line_magic("matplotlib", "inline")
+if ipython is not None:
+    if 'ipykernel' in sys.modules: # running in Jupyter
+        ipython.run_line_magic('matplotlib', 'inline')
+    else: # terminal IPython
+        ipython.run_line_magic('matplotlib', 'qt5')
 
 matplotlib.rcParams["figure.dpi"] = 150
 


### PR DESCRIPTION
This pull request updates the initialization logic for matplotlib in the `dartfish_pipeline.py` example to more reliably detect the execution environment and set the appropriate backend. The main change is to distinguish between running in a Jupyter notebook and a terminal IPython session, ensuring that plots display correctly in both contexts.

Environment detection and backend selection:

* Added a check for `'ipykernel'` in `sys.modules` to determine if the code is running in a Jupyter notebook, and set the matplotlib backend to `'inline'` in that case. If running in a terminal IPython session, sets the backend to `'qt5'`. (`examples/pipelines/dartfish_pipeline.py`)